### PR TITLE
Update SDK docs

### DIFF
--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -24,7 +24,7 @@
     <div id="header_wrap" style="height: 80px;">
       <header class="info-bar">
         <div class="menu-bar"><h1 id="project_title">
-<a class="menu-item" style="margin-left: 0px;" href="{{ site.baseurl }}/"><img src="https://hubmapconsortium.org/wp-content/uploads/2020/09/hubmap-type-white250.png" id="MenuLogo" alt="HuBMAP logo" height="40"></a>&nbsp;<a class="menu-item" href="overview.html">Overview</a>&nbsp;&nbsp;<a class="menu-item" href= "apis.html">APIs</a>
+<a class="menu-item" style="margin-left: 0px;" href="{{ site.baseurl }}/"><img src="https://hubmapconsortium.org/wp-content/uploads/2020/09/hubmap-type-white250.png" id="MenuLogo" alt="HuBMAP logo" height="40"></a>&nbsp;<a class="menu-item" href="overview.html">Overview</a>&nbsp;&nbsp;<a class="menu-item" href= "apis.html">APIs</a>&nbsp;&nbsp;<a class="menu-item" href= "/hubmapsdk.html">SDK</a>
 	</div></h1>
        </header>
     </div>

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -23,7 +23,7 @@
     <div id="header_wrap" style="height: 80px;">
       <header class="info-bar">
         <div class="menu-bar"><h1 id="project_title">
-<a class="menu-item" style="margin-left: 0px;" href="{{ site.baseurl }}/"><img src="https://hubmapconsortium.org/wp-content/uploads/2020/09/hubmap-type-white250.png" id="MenuLogo" alt="HuBMAP logo" height="40"></a>&nbsp;<a class="menu-item" href="overview.html">Overview</a>&nbsp;&nbsp;<a class="menu-item" href= "apis.html">APIs</a>
+<a class="menu-item" style="margin-left: 0px;" href="{{ site.baseurl }}/"><img src="https://hubmapconsortium.org/wp-content/uploads/2020/09/hubmap-type-white250.png" id="MenuLogo" alt="HuBMAP logo" height="40"></a>&nbsp;<a class="menu-item" href="overview.html">Overview</a>&nbsp;&nbsp;<a class="menu-item" href= "apis.html">APIs</a>&nbsp;&nbsp;<a class="menu-item" href= "/hubmapsdk.html">SDK</a>
 	</div></h1>
        </header>
     </div>

--- a/docs/entitysdk.md
+++ b/docs/entitysdk.md
@@ -1,7 +1,7 @@
-
-# Entity SDK   
-
 ---
+layout: page
+---
+# Entity SDK   
 
 ##  Entity SDK Overview
 The entity sdk may be used to access any functionality from the Entity API. In order to use the entity sdk, 

--- a/docs/hubmapsdk.md
+++ b/docs/hubmapsdk.md
@@ -1,11 +1,5 @@
-<!--
-# Feel free to add content and custom Front Matter to this file.
-# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
-layout: home
--->
-![hubmap logo](images/darkhumaplogo.PNG)
-# HuBMAP SDK
-
+---
+layout: page
 ---
 ### SDK Overview
 
@@ -35,6 +29,6 @@ urllib3<=1.26.7
 
 Each module within the hubmap_sdk contains a class corresponding to its respective HuBMAP API. This class is what gives access to the functionality of its given API. Follow the links below to learn more about each module including how to get started and a breakdown of each of its methods:
 
-* [Entity SDK](entitysdk.md)
-* [Search SDK](searchsdk.md)
+* [Entity SDK](entitysdk.html)
+* [Search SDK](searchsdk.html)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ layout: home
 
 ## Coming Soon
 
-[Hubmap SDK Documentation](hubmapsdk.md)
+[Hubmap SDK Documentation](hubmapsdk.html)
 
 
 

--- a/docs/searchsdk.md
+++ b/docs/searchsdk.md
@@ -1,7 +1,7 @@
-
-# Search SDK
-
 ---
+layout: page
+---
+# Search SDK
 
 ## Search SDK Overview
 


### PR DESCRIPTION
The SDK docs weren't working in local Jekyll environment and the .md page references were trying to download instead of display on Mac Firefox 
- use the standard `page` layout on SDK docs pages
 - added SDK menu pick on `home` and `page` layouts