### PR TITLE
make css refs absolute for home and page layouts

### DIFF
--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -6,9 +6,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,maximum-scale=2">
  <!--   <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}"> -->
-    <link rel="stylesheet" type="text/css" href="css/hm.css">
-    <link rel="stylesheet" type="text/css" href="css/hm-code.css">
-    <link rel="stylesheet" type="text/css" href="css/over.css">
+    <link rel="stylesheet" type="text/css" href="/css/hm.css">
+    <link rel="stylesheet" type="text/css" href="/css/hm-code.css">
+    <link rel="stylesheet" type="text/css" href="/css/over.css">
 
     <style>
     </style>

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -5,9 +5,9 @@
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,maximum-scale=2">
-    <link rel="stylesheet" type="text/css" href="css/hm.css">
-    <link rel="stylesheet" type="text/css" href="css/hm-code.css">
-    <link rel="stylesheet" type="text/css" href="css/over.css">
+    <link rel="stylesheet" type="text/css" href="/css/hm.css">
+    <link rel="stylesheet" type="text/css" href="/css/hm-code.css">
+    <link rel="stylesheet" type="text/css" href="/css/over.css">
 
     <style>
     </style>


### PR DESCRIPTION
This fixed the missing styling for the /assays/*.md files that use the page layout as well as any other future non-top-level file using the page or home layouts.