### PR TITLE
Switch use of specimen_type to sample_category

### DIFF
--- a/docs/elasticsearch_documents/file-info.md
+++ b/docs/elasticsearch_documents/file-info.md
@@ -35,11 +35,11 @@ processed, and may not reflect subsequent changes until a re-index is complete.
 
 ### `samples` Array Elements:
 
-| samples Element | Description                                                                                      |
-|-----------------|--------------------------------------------------------------------------------------------------|
-| uuid            | The uuid of a Sample entity whose specimen type is not 'organ', which is an ancestor of the file |
-| code            | A code for the specimen type. See [Tissue Sample Types](#tissue-sample-types) below              |
-| type            | A description for the tissue sample type of the specimen, specified as the "code"                |
+| samples Element | Description                                                                                        |
+|-----------------|----------------------------------------------------------------------------------------------------|
+| uuid            | The uuid of a Sample entity whose sample category is not 'organ', which is an ancestor of the file |
+| code            | A code for the sample category.                                                                    |
+| type            | A description for the sample category, specified as the "code"                                     |
 
 ### `organs` Array Elements:
 
@@ -57,55 +57,6 @@ processed, and may not reflect subsequent changes until a re-index is complete.
 | age            | A float value created from the Donor entity metadata for the [UMLS age group CUI C0001779](https://uts.nlm.nih.gov/uts/umls/concept/C0001779)  |
 | units          | The unit of measure for the age concept of the Donor entity metadata                                                                           |
 | race           | A UMLS preferred term from the Donor entity metadata for the [UMLS race group CUI C0034510](https://uts.nlm.nih.gov/uts/umls/concept/C0034510) |
-
-### Tissue Sample Types
-Examples are enumerated below, but the current, authoritative list is in the [tissue_sample_types.yaml](https://raw.githubusercontent.com/hubmapconsortium/search-api/main/src/search-schema/data/definitions/enums/tissue_sample_types.yaml) file of the search-api repository.
-- atacseq
-- biopsy
-- blood
-- cell_lysate
-- clarity_hydrogel
-- codex
-- cryosections_curls_from_fresh_frozen_oct
-- cryosections_curls_rnalater
-- ffpe_block
-- ffpe_slide
-- fixed_frozen_section_slide
-- fixed_tissue_piece
-- flash_frozen_liquid_nitrogen
-- formalin_fixed_oct_block
-- fresh_frozen_oct_block
-- fresh_frozen_section_slide
-- fresh_frozen_tissue
-- fresh_frozen_tissue_section
-- fresh_tissue
-- frozen_cell_pellet_buffy_coat
-- gdna
-- module
-- nuclei
-- nuclei_rnalater
-- organ
-- organ_piece
-- other
-- pbmc
-- pfa_fixed_frozen_oct_block
-- plasma
-- protein
-- ran_poly_a_enriched
-- rna_total
-- rnalater_treated_and_stored
-- rnaseq
-- scatacseq
-- scrnaseq
-- segment
-- seqfish
-- sequence_library
-- serum
-- single_cell_cryopreserved
-- snatacseq
-- snrnaseq
-- tissue_lysate
-- wgs
 
 ### Organ Type Codes
 Examples are enumerated below, but the current, authoritative list is in the [organ_types.yaml](https://raw.githubusercontent.com/hubmapconsortium/search-api/master/src/search-schema/data/definitions/enums/organ_types.yaml) file of the search-api repository.


### PR DESCRIPTION
Switch use of specimen_type to sample_category for forming the samples array of file info documents. files-api issue 19.

I tried the bundled Jekyll server to verify GitHub rendering, but got a startup error I'll have to work on.  I didn't know if we might want to add a fix for that to this branch before merging.

```
karl@KB-Precision-5560:~/PycharmProjects/software-docs$ docker run -it -p4000:4000 -v `pwd`:/software-docs hubmap/github-pages-server --platform linux/amd64
WARNING: The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested
exec /root/run-inside-docker.sh: exec format error
```
